### PR TITLE
update to 2.2.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pymssql" %}
-{% set version = "2.2.3" %}
-{% set sha256 = "b94fddc6d5f168205d14294d36969025967ff1837adcc1664c19968de61dca80" %}
-{% set build = "1" %}
+{% set version = "2.2.5" %}
+{% set sha256 = "857411c308ecb584a3ca633be30f1971d2a8cc0bcd978709b1abf96ff43767ad" %}
+{% set build = "0" %}
 
 package:
   name: {{ name|lower }}
@@ -57,7 +57,7 @@ about:
     dev_url: https://github.com/pymssql/pymssql
     doc_url: http://www.pymssql.org/en/stable/
     home: http://pymssql.org
-    license: LGPL-2.1-or-later
+    license: LGPL-2.1-only
     license_family: LGPL
     summary: DB-API interface to Microsoft SQL Server for Python. (new Cython-based
         version)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ about:
     dev_url: https://github.com/pymssql/pymssql
     doc_url: http://www.pymssql.org/en/stable/
     home: http://pymssql.org
-    license: LGPL
+    license: LGPL-2.1-or-later
     license_family: LGPL
     summary: DB-API interface to Microsoft SQL Server for Python. (new Cython-based
         version)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pymssql" %}
 {% set version = "2.2.3" %}
 {% set sha256 = "b94fddc6d5f168205d14294d36969025967ff1837adcc1664c19968de61dca80" %}
-{% set build = "0" %}
+{% set build = "1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,8 +55,8 @@ test:
 
 about:
     dev_url: https://github.com/pymssql/pymssql
-    doc_url: http://www.pymssql.org/en/stable/
-    home: http://pymssql.org
+    doc_url: https://www.pymssql.org/en/stable/
+    home: https://pymssql.org
     license: LGPL-2.1-only
     license_family: LGPL
     summary: DB-API interface to Microsoft SQL Server for Python. (new Cython-based

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "pymssql" %}
 {% set version = "2.2.3" %}
 {% set sha256 = "b94fddc6d5f168205d14294d36969025967ff1837adcc1664c19968de61dca80" %}
+{% set build = "0" %}
 
 package:
   name: {{ name|lower }}
@@ -14,8 +15,8 @@ source:
     - patches/0002-customize_compiler.patch
 
 build:
-  number: 0
-  skip: true  # [py<36]
+  number: {{ build }}
+  skip: True  # [py<36]
   script:
     - export LINK_FREETDS_STATICALLY=NO   # [unix]
     - set LINK_FREETDS_STATICALLY=NO      # [win]


### PR DESCRIPTION
Changelog:
- update version, checksum; reset build number
- correct license type
- correct `http` to `https` in URLs